### PR TITLE
Changed chirps version to 3.0

### DIFF
--- a/R/downloadplugin_chirps.R
+++ b/R/downloadplugin_chirps.R
@@ -22,13 +22,13 @@ utils::globalVariables(c(
 
 get_month_chirps <- function(start_date,
                              end_date,
-                             link_base = "https://data.chc.ucsb.edu/products/CHIRPS-2.0/") {
+                             link_base = "https://data.chc.ucsb.edu/products/CHIRPS/v3.0/") {
   dt <- chirpname_monthly(
     start_date = start_date,
     end_date = end_date
   )
 
-  dt[, sub_dir := "global_monthly/tifs/"]
+  dt[, sub_dir := "monthly/global/tifs/"]
 
   dt[, full_link := paste0(
     link_base,
@@ -64,7 +64,7 @@ get_month_chirps <- function(start_date,
 
 get_annual_chirps <- function(start_year,
                               end_year,
-                              link_base = "https://data.chc.ucsb.edu/products/CHIRPS-2.0/",
+                              link_base = "https://data.chc.ucsb.edu/products/CHIRPS/v3.0/",
                               cores = 1L) {
   dt <- chirpname_annual(
     start_year = start_year,
@@ -73,7 +73,7 @@ get_annual_chirps <- function(start_year,
 
   dt <- data.table(filename = dt)
 
-  dt[, sub_dir := "global_annual/tifs/"]
+  dt[, sub_dir := "annual/global/tifs/"]
 
   dt[, full_link := paste0(
     link_base,

--- a/R/downloadplugin_chirps_internals.R
+++ b/R/downloadplugin_chirps_internals.R
@@ -20,7 +20,7 @@ chirpname_annual <- function(start_year,
 
   year_dt <- data.table::data.table(
     year = year_list,
-    version = "chirps-v2.0.",
+    version = "chirps-v3.0.",
     ext = ".tif"
   )
 
@@ -41,7 +41,7 @@ chirpname_annual <- function(start_year,
 chirpname_monthly <- function(start_date,
                               end_date,
                               repo_interval = "month",
-                              filename_tag = "chirps-v2.0.",
+                              filename_tag = "chirps-v3.0.",
                               file_ext = ".tif.gz") {
   time_list <- check_valid_month(
     start_date = start_date,

--- a/R/downloadplugin_ntl.R
+++ b/R/downloadplugin_ntl.R
@@ -147,7 +147,7 @@ get_annual_ntl <- function(year,
   )
 
   ### find the list of links on the page
-  webpage <- rvest::read_html(url_link)
+  webpage <- rvest::read_html(httr::GET(url_link, config = httr::config(ssl_verifypeer = FALSE)))
 
   download_links <- webpage %>%
     rvest::html_nodes("a") %>%


### PR DESCRIPTION
Hi @DianaJaganjac, 

I was having trouble downloading CHIRPS today. It seems like they erased all data for v2.0. I'm not sure, though. But I made the changes to download v3.0. I'm not sure if this helps. Feel free to ignore it if it is not helpful. 